### PR TITLE
Fix bug in ajax callback

### DIFF
--- a/tb_megamenu.ajax.inc
+++ b/tb_megamenu.ajax.inc
@@ -20,7 +20,7 @@ function tb_megamenu_request() {
             db_update('tb_megamenus')->fields(array('menu_config' => $menu_config, 'block_config' => $block_config))->condition('menu_name', $menu_name)->execute();
           }
           else {
-            db_insert('tb_megamenus')->fields(array('menu_name' => $menu_name, 'block_config' => $block_config, 'menu_config' => $menu_config))->execute();
+            db_insert('tb_megamenus')->fields(array('menu_name' => $menu_name, 'block_config' => $block_config, 'menu_config' => $menu_config, 'language' => $language->langcode))->execute();
           }
         }
       }


### PR DESCRIPTION
The ajax callback doesn't set the language (which is a condition elsewhere in the module), so we end up with menus with '' as the language. I've added it to the db_insert callback.

Fixes Issue 10